### PR TITLE
Remove workflow-dispatch inputs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,39 +2,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-    inputs:
-      fstar:
-        description: "Fstar"
-        type: "string"
-        default: "master"
-      karamel:
-        description: "KaRaMeL"
-        type: "string"
-        default: "master"
-      hax:
-        description: "Hax"
-        type: "string"
-        default: "main"
-      charon:
-        description: "Charon"
-        type: "string"
-        default: "main"
-      eurydice:
-        description: "Eurydice"
-        type: "string"
-        default: "main"
-      aeneas:
-        description: "Aeneas"
-        type: "string"
-        default: "main"
-      libcrux:
-        description: "Libcrux"
-        type: "string"
-        default: "main"
-      bertie:
-        description: "Bertie"
-        type: "string"
-        default: "main"
   push:
     branches-ignore:
       - main
@@ -52,13 +19,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: update
-        env:
-          HAX_BRANCH: ${{ inputs.hax }}
-          CHARON_BRANCH: ${{ inputs.charon }}
-          AENEAS_BRANCH: ${{ inputs.aeneas }}
-          EURYDICE_BRANCH: ${{ inputs.eurydice }}
-          LIBCRUX_BRANCH: ${{ inputs.libcrux }}
-          BERTIE_BRANCH: ${{ inputs.bertie }}
         run: ./update.sh
 
       # Commit the update onto a new branch

--- a/update.sh
+++ b/update.sh
@@ -1,24 +1,7 @@
 #!/usr/bin/env bash
 
-FSTAR_BRANCH="${FSTAR_BRANCH:-master}"
-KARAMEL_BRANCH="${KARAMEL_BRANCH:-master}"
-HAX_BRANCH="${HAX_BRANCH:-main}"
-CHARON_BRANCH="${CHARON_BRANCH:-main}"
-AENEAS_BRANCH="${AENEAS_BRANCH:-main}"
-EURYDICE_BRANCH="${EURYDICE_BRANCH:-main}"
-LIBCRUX_BRANCH="${LIBCRUX_BRANCH:-main}"
-BERTIE_BRANCH="${BERTE_BRANCH:-main}"
-
 # Update `flake.lock`
-nix flake update \
-   --override-input hax "github:hacspec/hax?ref=$HAX_BRANCH" \
-   --override-input charon "github:aeneasverif/charon?ref=$CHARON_BRANCH" \
-   --override-input aeneas "github:aeneasverif/aeneas?ref=$AENEAS_BRANCH" \
-   --override-input eurydice "github:aeneasverif/eurydice?ref=$EURYDICE_BRANCH" \
-   --override-input eurydice/karamel "github:FStarLang/karamel?ref=$KARAMEL_BRANCH" \
-   --override-input eurydice/karamel/fstar "github:FStarLang/fstar?ref=$FSTAR_BRANCH" \
-   --override-input libcrux "github:cryspen/libcrux?ref=$LIBCRUX_BRANCH" \
-   --override-input bertie "github:cryspen/bertie?ref=$BERTIE_BRANCH"
+nix flake update
 
 # Update the `Cargo.lock` file we keep for libcrux
 LIBCRUX_COMMIT="$(nix shell nixpkgs#jq --command jq -r .nodes.libcrux.locked.rev flake.lock)"


### PR DESCRIPTION
We don't use them and it's easy to do locally. This removes boilerplate.