### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: update
-        run: nix shell nixpkgs#jq --command ./update.sh
+        run: nix develop --command ./update.sh
 
       # Commit the update onto a new branch
       - name: commit

--- a/flake.nix
+++ b/flake.nix
@@ -81,5 +81,16 @@
         };
         bertie = packages.bertie;
       };
+      # Make a dev-shell with an appropriate rust toolchain, used to regenerate
+      # the `Cargo.lock`s.
+      devShells.default =
+        let
+          pkgs = import inputs.nixpkgs { inherit system; };
+          rustToolchain = inputs.charon.packages.${system}.rustToolchain;
+          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+        in
+        craneLib.devShell {
+          packages = [ pkgs.jq ];
+        };
     });
 }

--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,7 @@ function generate_cargo_lock() {
    git clone "https://github.com/$OWNER/$REPO" tmp
    cd tmp
    git checkout "$COMMIT"
-   nix develop --command cargo generate-lockfile
+   cargo generate-lockfile
    cd ..
    mv tmp/Cargo.lock "$PROJECT"-Cargo.lock
    rm -rf tmp


### PR DESCRIPTION
Once again the `Cargo.lock` hacks are causing trouble. This time it's because fetchGit can't be used in pure mode, yet we can't pin the `circus-green` commit in libcrux because the whole point is to stay up-to-date. To fix this, we use our own dev-shell instead of libcrux's. We only need a rust toolchain anyway.