### PR TITLE
Use a single nixpkgs version for everything

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,15 +14,15 @@
           "fstar"
         ],
         "nixpkgs": [
-          "nixpkgs-ocaml"
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1743241654,
-        "narHash": "sha256-TDhrbgbLkCE+dpVqMJ7yuJZwBYo4BLd05cUEmn555ls=",
+        "lastModified": 1743585546,
+        "narHash": "sha256-5Th/HC4eLmlNsalMZzQYTgNjq9AVKShUAf4tBg8LQqs=",
         "owner": "aeneasverif",
         "repo": "aeneas",
-        "rev": "8448ccd388bddfec12fb31d4bf61d7541728bceb",
+        "rev": "86ec2f1e6ec85cd9e3a3260816bcc8d5292a89a0",
         "type": "github"
       },
       "original": {
@@ -73,16 +73,16 @@
           "nixpkgs"
         ],
         "nixpkgs-ocaml": [
-          "nixpkgs-ocaml"
+          "nixpkgs"
         ],
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1743424578,
-        "narHash": "sha256-W81SjPxzMoMqcU25A7iYHJRLJhLdTv5dlfl2zX0oeFI=",
+        "lastModified": 1743508719,
+        "narHash": "sha256-bZZfS0bwHRQh6p3svYqVBo65xdJgVejutU1oCd2QyKM=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "294988ac5efd84aede2c06667f23e69d01aa1281",
+        "rev": "9582b0580f8bf8ae5c1c3a66df37301c1e6756cc",
         "type": "github"
       },
       "original": {
@@ -117,20 +117,15 @@
         ],
         "karamel": "karamel",
         "nixpkgs": [
-          "eurydice",
-          "karamel",
-          "nixpkgs"
-        ],
-        "recent_nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1743162870,
-        "narHash": "sha256-1dI5C0jsMZjgu8EpVBKafeL0or90TMkRhwg0c3rLbHs=",
+        "lastModified": 1743586238,
+        "narHash": "sha256-BxJVtO2yu9gEgXiyEZk6/OPQg/6MRR5s/RU1QBaOWRQ=",
         "owner": "aeneasverif",
         "repo": "eurydice",
-        "rev": "9c587e76b6724c4a4e887b4443327c5680544288",
+        "rev": "9f45c5b6710ac03aa157299391233be90bc1565c",
         "type": "github"
       },
       "original": {
@@ -177,11 +172,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1743441086,
-        "narHash": "sha256-N17vE2QlzipVT1cKIv745dAzBHHJEvmEWlQmQKQrkww=",
+        "lastModified": 1743548018,
+        "narHash": "sha256-EwSwoSWBfULpW+6fcHaD7yQBeEhFRbsH1iqNcShDAg0=",
         "owner": "FStarLang",
         "repo": "fstar",
-        "rev": "17d21d6d1a482f2176b236c78340bfdcff42e53f",
+        "rev": "135748c5ab21429d0cc651c600f8fd6930c212a0",
         "type": "github"
       },
       "original": {
@@ -227,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743433496,
-        "narHash": "sha256-F/2pB6sddVnFcipC7RWxDYBIHMKexFMM3K/neXvjYWY=",
+        "lastModified": 1743586353,
+        "narHash": "sha256-zTcS7IeQytjKRmG3BEqQF3OM0qT0pFVc3HHXPpBTycU=",
         "owner": "hacspec",
         "repo": "hax",
-        "rev": "ee8b732c55b2a2b008821dc2f25a14b2fe781c29",
+        "rev": "b1b8ae3a7d866d93d35f983df11b2d47099015c6",
         "type": "github"
       },
       "original": {
@@ -251,17 +246,15 @@
         "fstar": "fstar",
         "nixpkgs": [
           "eurydice",
-          "karamel",
-          "fstar",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1743108959,
-        "narHash": "sha256-a8G5wREubqI4y8XI+e+O0kvIW1XgXjRe44LXBnZuqB4=",
+        "lastModified": 1743531403,
+        "narHash": "sha256-udeRfVwBZ7mE1baXGIi3FYGsSm/4V3TbyitjcjYlbV0=",
         "owner": "FStarLang",
         "repo": "karamel",
-        "rev": "172ee7878e68005c70956ef8045d1ecaba39fd3f",
+        "rev": "65bd08092b5872bdfd1f6cb6028a8a7a605fe939",
         "type": "github"
       },
       "original": {
@@ -272,37 +265,25 @@
     },
     "libcrux": {
       "inputs": {
-        "charon": [
-          "charon"
-        ],
-        "crane": [
-          "crane"
-        ],
         "eurydice": [
           "eurydice"
         ],
         "flake-utils": [
           "flake-utils"
         ],
-        "fstar": [
-          "fstar"
-        ],
         "hax": [
           "hax"
-        ],
-        "karamel": [
-          "karamel"
         ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1743416478,
-        "narHash": "sha256-7pI73rPwJA8yAgZEfcKL/wC+9OWWu+6IoV4mPatXIlA=",
+        "lastModified": 1743576790,
+        "narHash": "sha256-zjRuS6m/1+xfSACErRDDxTuSkk2vF8hLyua4IqBACjI=",
         "owner": "cryspen",
         "repo": "libcrux",
-        "rev": "36d7d392e1c2a6f90c9f5224d360d43895c4ac8e",
+        "rev": "85c4f122efebe1249c6bf0ea9fe074ba8b449ed9",
         "type": "github"
       },
       "original": {
@@ -328,11 +309,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743470143,
-        "narHash": "sha256-MkEMgX65cculZKy7jjkWS+dQCO6bT/h2dvEmkBAxNCA=",
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "84a380590bf7e989c1de604467e289bc9d750ed1",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
         "type": "github"
       },
       "original": {
@@ -364,10 +345,6 @@
         ],
         "libcrux": "libcrux",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-ocaml": [
-          "eurydice",
-          "nixpkgs"
-        ],
         "rust-overlay": [
           "charon",
           "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -41,11 +41,7 @@
       url = "github:cryspen/libcrux";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
-      inputs.crane.follows = "crane";
-      inputs.charon.follows = "charon";
       inputs.eurydice.follows = "eurydice";
-      inputs.fstar.follows = "fstar";
-      inputs.karamel.follows = "karamel";
       inputs.hax.follows = "hax";
     };
     bertie = {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
     flake-utils.follows = "fstar/flake-utils";
-    crane.url = "github:ipetkov/crane/da87d1af7e4e09fd0271432340a5cadf3eb96005";
+    crane.url = "github:ipetkov/crane";
     karamel.follows = "eurydice/karamel";
     karamel.inputs.nixpkgs.follows = "nixpkgs";
     fstar.follows = "eurydice/karamel/fstar";

--- a/flake.nix
+++ b/flake.nix
@@ -2,29 +2,30 @@
   # The inputs we care about are: hax, charon, eurydice, libcrux, bertie. We
   # take good care to avoid duplicated inputs to save on evaluation time.
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs"; # Recent nixpkgs for rust-overlay
-    nixpkgs-ocaml.follows = "eurydice/nixpkgs"; # eurydice nixpkgs for ocaml compat
+    nixpkgs.url = "github:nixos/nixpkgs";
     flake-utils.follows = "fstar/flake-utils";
     crane.url = "github:ipetkov/crane/da87d1af7e4e09fd0271432340a5cadf3eb96005";
     karamel.follows = "eurydice/karamel";
+    karamel.inputs.nixpkgs.follows = "nixpkgs";
     fstar.follows = "eurydice/karamel/fstar";
+    fstar.inputs.nixpkgs.follows = "nixpkgs";
     rust-overlay.follows = "charon/rust-overlay";
     charon = {
       url = "github:aeneasverif/charon";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-ocaml.follows = "nixpkgs-ocaml";
+      inputs.nixpkgs-ocaml.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
       inputs.crane.follows = "crane";
     };
     aeneas = {
       url = "github:aeneasverif/aeneas";
-      inputs.nixpkgs.follows = "nixpkgs-ocaml";
+      inputs.nixpkgs.follows = "nixpkgs";
       inputs.charon.follows = "charon";
       inputs.fstar.follows = "fstar";
     };
     eurydice = {
       url = "github:aeneasverif/eurydice";
-      inputs.recent_nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
       inputs.charon.follows = "charon";
     };


### PR DESCRIPTION
I needed different versions because of ocaml toolchain issues but I've understood and fixed the issues now.